### PR TITLE
fix: VolumeAttachments WIP 

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/time/rate"

--- a/pkg/controllers/node/termination/terminator/events/events.go
+++ b/pkg/controllers/node/termination/terminator/events/events.go
@@ -43,3 +43,13 @@ func NodeFailedToDrain(node *v1.Node, err error) events.Event {
 		DedupeValues:   []string{node.Name},
 	}
 }
+
+func NodeVolumeAttachmentsRemaining(node *v1.Node, err error) events.Event {
+	return events.Event{
+		InvolvedObject: node,
+		Type:           v1.EventTypeWarning,
+		Reason:         "VolumeAttachmentsRemaining",
+		Message:        fmt.Sprintf("Volume attachments remaining on node, %s", err),
+		DedupeValues:   []string{node.Name},
+	}
+}

--- a/pkg/controllers/node/termination/terminator/terminator.go
+++ b/pkg/controllers/node/termination/terminator/terminator.go
@@ -19,15 +19,17 @@ package terminator
 import (
 	"context"
 	"fmt"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"time"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	nodeutil "sigs.k8s.io/karpenter/pkg/utils/node"
 
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -19,13 +19,14 @@ package operator
 import (
 	"context"
 	"fmt"
-	storagev1 "k8s.io/api/storage/v1"
 	"net/http"
 	"net/http/pprof"
 	"runtime"
 	"runtime/debug"
 	"sync"
 	"time"
+
+	storagev1 "k8s.io/api/storage/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
 	coordinationv1 "k8s.io/api/coordination/v1"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -19,6 +19,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	storagev1 "k8s.io/api/storage/v1"
 	"net/http"
 	"net/http/pprof"
 	"runtime"
@@ -203,6 +204,9 @@ func NewOperator() (context.Context, *Operator) {
 	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &v1beta1.NodeClaim{}, "spec.nodeClassRef.name", func(o client.Object) []string {
 		return []string{o.(*v1beta1.NodeClaim).Spec.NodeClassRef.Name}
 	}), "failed to setup nodeclaim nodeclassref name indexer")
+	lo.Must0(mgr.GetFieldIndexer().IndexField(ctx, &storagev1.VolumeAttachment{}, "spec.nodeName", func(o client.Object) []string {
+		return []string{o.(*storagev1.VolumeAttachment).Spec.NodeName}
+	}), "failed to setup volumeattachment indexer")
 
 	lo.Must0(mgr.AddReadyzCheck("manager", func(req *http.Request) error {
 		return lo.Ternary(mgr.GetCache().WaitForCacheSync(req.Context()), nil, fmt.Errorf("failed to sync caches"))

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -19,6 +19,7 @@ package node
 import (
 	"context"
 	"fmt"
+
 	storagev1 "k8s.io/api/storage/v1"
 
 	"github.com/samber/lo"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

In order for a stateful pod to smoothly migrate from terminating node to new node...

0. Consolidation event starts
1. Stateful pods must terminate
2. EBS CSI Node pod must unmount all filesystems (NodeUnpublish & NodeUnstage RPCs)
3. EBS CSI Controller pod must detach all volumes from instance
4. Karpenter terminates EC2 Instance
5. Karpenter ensures Node object deleted from Kubernetes

Problems:
A. If 2 doesn't happen, today there's a 6+ minute delay in stateful pod migration because Kubernetes is afraid volume still attached and mounted to instance (6+ min delay)
B. If 3 doesn't happen, the new stateful pod can't start until consolidated instance is terminated which auto-detaches volumes (1+ min delay)

Solutions:
1. [Scope Medium] We can increase the likelihood of solving both A and B by having karpenter wait (on VolumeAttachment objects dissapearing) between 3 & 4.
2. [Scope Small] We can 100% solve A (that 6 min / soon-to-be-infinite delay)  by applying the [node.kubernetes.io/out-of-service:nodeshutdown:NoExecute](http://node.kubernetes.io/out-of-service:nodeshutdown:NoExecute) taint on the node between 4 and 5.

**How was this change tested?**

Manual WIP

Need to also add following rules to clusterrole.yaml in `karpenter-provider-aws`

```
  - apiGroups: ["storage.k8s.io"]
    resources: ["volumeattachments"]
    verbs: ["get", "list", "watch"]

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
